### PR TITLE
Fix Sentry extension (install by composer)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -765,7 +765,11 @@ RUN set -x; \
 	&& cat composer.json.bak | jq '. + {"prefer-stable": true}' > composer.json \
 	&& rm composer.json.bak \
 	&& composer clear-cache \
-	&& composer update --no-dev --with-dependencies --no-cache
+	&& git config --global url."https://github.com/WikiTeq/mediawiki-extension-RemoteWiki.git".insteadOf "git@github.com:WikiTeq/mediawiki-extension-RemoteWiki.git" \
+	&& git config --global url."https://github.com/WikiTeq/mediawiki-api-base.git".insteadOf "git@github.com:WikiTeq/mediawiki-api-base.git" \
+	&& git config --global url."https://github.com/WikiTeq/mediawiki-extensions-Sentry.git".insteadOf "git@github.com:WikiTeq/mediawiki-extensions-Sentry.git" \
+	&& composer update --no-dev --with-dependencies \
+	&& composer clear-cache
 
 ################# Patches #################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -572,10 +572,6 @@ RUN set -x; \
 	&& rmdir SemanticQueryInterface \
 	&& ln -s SQI.php SemanticQueryInterface.php \
 	&& rm -fr .git \
-	# Sentry
-	&& git clone --single-branch -b master https://github.com/WikiTeq/mediawiki-extensions-Sentry.git $MW_HOME/extensions/Sentry \
-	&& cd $MW_HOME/extensions/Sentry \
-	&& git checkout -q 51ffdd6474a02476adce583edfe647616c6f117a \
 	# ShowMe
 	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/ShowMe $MW_HOME/extensions/ShowMe \
 	&& cd $MW_HOME/extensions/ShowMe \

--- a/Dockerfile
+++ b/Dockerfile
@@ -572,6 +572,10 @@ RUN set -x; \
 	&& rmdir SemanticQueryInterface \
 	&& ln -s SQI.php SemanticQueryInterface.php \
 	&& rm -fr .git \
+	# Sentry
+	&& git clone --single-branch -b master https://github.com/WikiTeq/mediawiki-extensions-Sentry.git $MW_HOME/extensions/Sentry \
+	&& cd $MW_HOME/extensions/Sentry \
+	&& git checkout -q 51ffdd6474a02476adce583edfe647616c6f117a \
 	# ShowMe
 	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/ShowMe $MW_HOME/extensions/ShowMe \
 	&& cd $MW_HOME/extensions/ShowMe \
@@ -765,9 +769,6 @@ RUN set -x; \
 	&& cat composer.json.bak | jq '. + {"prefer-stable": true}' > composer.json \
 	&& rm composer.json.bak \
 	&& composer clear-cache \
-	&& git config --global url."https://github.com/WikiTeq/mediawiki-extension-RemoteWiki.git".insteadOf "git@github.com:WikiTeq/mediawiki-extension-RemoteWiki.git" \
-	&& git config --global url."https://github.com/WikiTeq/mediawiki-api-base.git".insteadOf "git@github.com:WikiTeq/mediawiki-api-base.git" \
-	&& git config --global url."https://github.com/WikiTeq/mediawiki-extensions-Sentry.git".insteadOf "git@github.com:WikiTeq/mediawiki-extensions-Sentry.git" \
 	&& composer update --no-dev --with-dependencies \
 	&& composer clear-cache
 

--- a/_sources/configs/composer.canasta.json
+++ b/_sources/configs/composer.canasta.json
@@ -41,7 +41,7 @@
 	"repositories": [
 		{
 			"type": "vcs",
-			"url": "https://github.com/WikiTeq/mediawiki-extension-RemoteWiki"
+			"url": "https://github.com/WikiTeq/mediawiki-extension-RemoteWiki.git"
 		},
 		{
 			"type": "vcs",
@@ -49,7 +49,7 @@
 		},
 		{
 			"type": "vcs",
-			"url": "https://github.com/wikimedia/mediawiki-extensions-Sentry"
+			"url": "https://github.com/WikiTeq/mediawiki-extensions-Sentry.git"
 		}
 	]
 }

--- a/_sources/configs/composer.canasta.json
+++ b/_sources/configs/composer.canasta.json
@@ -46,6 +46,10 @@
 		{
 			"type": "vcs",
 			"url": "https://github.com/WikiTeq/mediawiki-api-base.git"
+		},
+		{
+			"type": "vcs",
+			"url": "https://github.com/wikimedia/mediawiki-extensions-Sentry.git"
 		}
 	]
 }

--- a/_sources/configs/composer.canasta.json
+++ b/_sources/configs/composer.canasta.json
@@ -10,6 +10,7 @@
 		"mediawiki/semantic-compound-queries": "2.1.0",
 		"mediawiki/semantic-extra-special-properties": "2.1.0",
 		"mediawiki/semantic-scribunto": "2.1.0",
+		"mediawiki/sentry": "dev-master#51ffdd6474a02476adce583edfe647616c6f117a",
 		"mediawiki/simple-batch-upload": "1.8.2",
 		"mediawiki/bootstrap-components": "4.0.1",
 		"mediawiki/sub-page-list": "1.6.1",

--- a/_sources/configs/composer.canasta.json
+++ b/_sources/configs/composer.canasta.json
@@ -10,7 +10,6 @@
 		"mediawiki/semantic-compound-queries": "2.1.0",
 		"mediawiki/semantic-extra-special-properties": "2.1.0",
 		"mediawiki/semantic-scribunto": "2.1.0",
-		"mediawiki/sentry": "dev-master#51ffdd6474a02476adce583edfe647616c6f117a",
 		"mediawiki/simple-batch-upload": "1.8.2",
 		"mediawiki/bootstrap-components": "4.0.1",
 		"mediawiki/sub-page-list": "1.6.1",
@@ -32,6 +31,7 @@
 				"extensions/Widgets/composer.json",
 				"extensions/GoogleAnalyticsMetrics/composer.json",
 				"extensions/SemanticExternalQueryLookup/composer.json",
+				"extensions/Sentry/composer.json",
 				"extensions/OpenIDConnect/composer.json",
 				"extensions/WSOAuth/composer.json",
 				"extensions/Mpdf/composer.json"
@@ -41,15 +41,11 @@
 	"repositories": [
 		{
 			"type": "vcs",
-			"url": "https://github.com/WikiTeq/mediawiki-extension-RemoteWiki.git"
+			"url": "https://github.com/WikiTeq/mediawiki-extension-RemoteWiki"
 		},
 		{
 			"type": "vcs",
 			"url": "https://github.com/WikiTeq/mediawiki-api-base.git"
-		},
-		{
-			"type": "vcs",
-			"url": "https://github.com/WikiTeq/mediawiki-extensions-Sentry.git"
 		}
 	]
 }

--- a/_sources/configs/composer.canasta.json
+++ b/_sources/configs/composer.canasta.json
@@ -49,7 +49,7 @@
 		},
 		{
 			"type": "vcs",
-			"url": "https://github.com/wikimedia/mediawiki-extensions-Sentry.git"
+			"url": "https://github.com/wikimedia/mediawiki-extensions-Sentry"
 		}
 	]
 }


### PR DESCRIPTION
It throws PHP Fatal error:  Uncaught Error: Class 'Raven_Client' not found
 in /var/www/mediawiki/w/extensions/Sentry/includes/SentryHooks.php:69