### PR TITLE
Echo: update to newer 1.39 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -247,7 +247,7 @@ RUN set -x; \
 	# Echo
 	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Echo $MW_HOME/extensions/Echo \
 	&& cd $MW_HOME/extensions/Echo \
-	&& git checkout -q fdbc2cafdc412dc60d4345511defe9ee393efecf \
+	&& git checkout -q 8f0ec57ddd73420ab5269bd9da0ff2133e90585f \
 	# Editcount
 	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Editcount $MW_HOME/extensions/Editcount \
 	&& cd $MW_HOME/extensions/Editcount \


### PR DESCRIPTION
Include commit [1] so that upgrades from 1.35 are not broken, see T322143.

[1] https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Echo/+/869711