### PR TITLE
Use cache directory with array localisation cache by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -862,10 +862,8 @@ RUN set -x; \
 RUN set -x; \
 	# Move files to $MW_ORIGIN_FILES directory
 	mv $MW_HOME/images $MW_ORIGIN_FILES/ \
-	&& mv $MW_HOME/cache $MW_ORIGIN_FILES/ \
-	# Create symlinks from $MW_VOLUME to the wiki root for images and cache directories
-	&& ln -s $MW_VOLUME/images $MW_HOME/images \
-	&& ln -s $MW_VOLUME/cache $MW_HOME/cache
+	# Create symlinks from $MW_VOLUME to the wiki root for images directory
+	&& ln -s $MW_VOLUME/images $MW_HOME/images
 
 FROM base as final
 
@@ -910,7 +908,8 @@ ENV MW_AUTOUPDATE=true \
 	LOG_FILES_REMOVE_OLDER_THAN_DAYS=10 \
 	MEDIAWIKI_MAINTENANCE_AUTO_ENABLED=false \
 	MW_DEBUG_MODE=false \
-	MW_SENTRY_DSN=""
+	MW_SENTRY_DSN="" \
+	MW_USE_CACHE_DIRECTORY=1
 
 COPY _sources/configs/msmtprc /etc/
 COPY _sources/configs/mediawiki.conf /etc/apache2/sites-enabled/

--- a/_sources/canasta/DockerSettings.php
+++ b/_sources/canasta/DockerSettings.php
@@ -290,7 +290,10 @@ $wgShellLocale = "en_US.utf8";
 ## Set $wgCacheDirectory to a writable directory on the web server
 ## to make your wiki go slightly faster. The directory should not
 ## be publicly accessible from the web.
-$wgCacheDirectory = getenv( 'MW_USE_CACHE_DIRECTORY' ) ? "$IP/cache" : false;
+$wgCacheDirectory = getenv( 'MW_USE_CACHE_DIRECTORY' ) ? "$DOCKER_MW_VOLUME/cache" : false;
+if ( $wgCacheDirectory ) {
+	$wgLocalisationCacheConf['store'] = 'array';
+}
 
 # Do not overwrite $wgSecretKey with empty string if MW_SECRET_KEY is not defined
 $wgSecretKey = getenv( 'MW_SECRET_KEY' ) ?: $wgSecretKey;

--- a/_sources/scripts/run-apache.sh
+++ b/_sources/scripts/run-apache.sh
@@ -25,6 +25,7 @@ rsync -ah --inplace --ignore-existing \
 # Create needed directories
 #TODO check below command need
 mkdir -p "$MW_VOLUME"/extensions/SemanticMediaWiki/config
+mkdir -p "$MW_VOLUME"/cache
 
 /update-docker-gateway.sh
 


### PR DESCRIPTION
This can make short requests a bit faster and reduce DB pressure. It causes localization cache to be cached via opcache instead of fetched from DB.

Disable the code that makes $IP/cache a symbolic link and rm's .htaccess. It is not reccomended that the cache directory be in the web directory. It matters less for the "array" method of localisation cache, but for other methods (which we are not using) this could result in private info being leaked.

I tested this by building the image locally, and using it with a modified version of the demo site docker compose.

https://wikiteq.atlassian.net/browse/WIK-799