### PR TITLE
Use cache directory with cdb localisation cache by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -910,7 +910,8 @@ ENV MW_AUTOUPDATE=true \
 	LOG_FILES_REMOVE_OLDER_THAN_DAYS=10 \
 	MEDIAWIKI_MAINTENANCE_AUTO_ENABLED=false \
 	MW_DEBUG_MODE=false \
-	MW_SENTRY_DSN=""
+	MW_SENTRY_DSN="" \
+	MW_USE_CACHE_DIRECTORY=1
 
 COPY _sources/configs/msmtprc /etc/
 COPY _sources/configs/mediawiki.conf /etc/apache2/sites-enabled/

--- a/_sources/canasta/DockerSettings.php
+++ b/_sources/canasta/DockerSettings.php
@@ -290,7 +290,7 @@ $wgShellLocale = "en_US.utf8";
 ## Set $wgCacheDirectory to a writable directory on the web server
 ## to make your wiki go slightly faster. The directory should not
 ## be publicly accessible from the web.
-$wgCacheDirectory = getenv( 'MW_USE_CACHE_DIRECTORY' ) ? "$DOCKER_MW_VOLUME/l10n_cache" : false;
+$wgCacheDirectory = isEnvTrue( 'MW_USE_CACHE_DIRECTORY' ) ? "$DOCKER_MW_VOLUME/l10n_cache" : false;
 
 # Do not overwrite $wgSecretKey with empty string if MW_SECRET_KEY is not defined
 $wgSecretKey = getenv( 'MW_SECRET_KEY' ) ?: $wgSecretKey;

--- a/_sources/canasta/DockerSettings.php
+++ b/_sources/canasta/DockerSettings.php
@@ -290,7 +290,7 @@ $wgShellLocale = "en_US.utf8";
 ## Set $wgCacheDirectory to a writable directory on the web server
 ## to make your wiki go slightly faster. The directory should not
 ## be publicly accessible from the web.
-$wgCacheDirectory = getenv( 'MW_USE_CACHE_DIRECTORY' ) ? "$IP/cache" : false;
+$wgCacheDirectory = getenv( 'MW_USE_CACHE_DIRECTORY' ) ? "$DOCKER_MW_VOLUME/l10n_cache" : false;
 
 # Do not overwrite $wgSecretKey with empty string if MW_SECRET_KEY is not defined
 $wgSecretKey = getenv( 'MW_SECRET_KEY' ) ?: $wgSecretKey;

--- a/_sources/scripts/run-apache.sh
+++ b/_sources/scripts/run-apache.sh
@@ -25,6 +25,7 @@ rsync -ah --inplace --ignore-existing \
 # Create needed directories
 #TODO check below command need
 mkdir -p "$MW_VOLUME"/extensions/SemanticMediaWiki/config
+mkdir -p "$MW_VOLUME"/l10n_cache
 
 /update-docker-gateway.sh
 


### PR DESCRIPTION
Use a cache directory that is not in the web root to follow best practise.