### PR TITLE
Allow PageForms to be enabled via ENV variable, ensure enableSemantics() is called right after SMW load

### DIFF
--- a/_sources/canasta/DockerSettings.php
+++ b/_sources/canasta/DockerSettings.php
@@ -144,7 +144,7 @@ const DOCKER_EXTENSIONS = [
 	'OpenIDConnect',
 	'PDFEmbed',
 	'PageExchange',
-//	'PageForms',   must be enabled manually after enableSemantics()
+	'PageForms',
 	'PageImages', # bundled
 	'PageSchemas',
 	'ParserFunctions', # bundled
@@ -363,9 +363,14 @@ if ( $dockerLoadExtensions ) {
 		// Enable SemanticMediaWiki first, because some Semantic extension don't work in other case
 		if ( isset( $dockerLoadExtensions['SemanticMediaWiki'] ) ) {
 			wfLoadExtension( 'SemanticMediaWiki' );
+			enableSemantics( $wgServer, true );
+		}
+		// Ensure PageForms is always enabled after SemanticMediaWiki
+		if ( isset( $dockerLoadExtensions['PageForms'] ) ) {
+			wfLoadExtension( 'PageForms' );
 		}
 		foreach ( $dockerLoadExtensions as $extension ) {
-			if ( $extension === 'SemanticMediaWiki' ) {
+			if ( $extension === 'SemanticMediaWiki' || $extension === 'PageForms' ) {
 				// Already loaded above ^
 				continue;
 			}


### PR DESCRIPTION
**Warning**: this may be a breaking change because before, it was necessary to call `enableSemantics()` and `wfLoadExtension('PageForms')` on a stack settings file, thus wikis running any Taqasta version before this patch, very likely to have these instructions on their settings files

**Upgrading**: 

* Remove `enableSemantics()` call from settings file
* Check if `PageForms` is present on the `MW_LOAD_EXTENSIONS` and if so, remove `wfLoadExtension('PageForms')` call from settings file, otherwise - keep as it (or remove the load call from the settings file and move the `PageForms` into `MW_LOAD_EXTENSIONS` instead)