### PR TITLE
Migrates HeaderFooter to Wikia fork [WIK-1178]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -366,9 +366,9 @@ RUN set -x; \
 RUN set -x; \
 	cd $MW_HOME/extensions \
 	# HeaderFooter
-	&& git clone https://github.com/enterprisemediawiki/HeaderFooter.git $MW_HOME/extensions/HeaderFooter \
+	&& git clone https://github.com/Wikia/HeaderFooter.git $MW_HOME/extensions/HeaderFooter \
 	&& cd $MW_HOME/extensions/HeaderFooter \
-	&& git checkout -q eee7d2c1a3373c7d6b326fd460e5d4859dd22c40 \
+	&& git checkout -q 0f582dd1ddf2d3e79907e064e68534eeff76be90 \
 	# HeaderTabs (v2.2)
 	&& git clone --single-branch -b master https://gerrit.wikimedia.org/r/mediawiki/extensions/HeaderTabs $MW_HOME/extensions/HeaderTabs \
 	&& cd $MW_HOME/extensions/HeaderTabs \


### PR DESCRIPTION
Enterprisemediawiki version is broken on 1.39, this commit migrates the extension to Wikia version (REL1_39) branch