### PR TITLE
Update variable in sitemap generation script

### DIFF
--- a/_sources/scripts/mwsitemapgen.sh
+++ b/_sources/scripts/mwsitemapgen.sh
@@ -44,7 +44,7 @@ while true; do
     # generate the sitemap
     php "$SCRIPT" \
       --fspath="$MW_HOME/sitemap/$MW_SITEMAP_SUBDIR" \
-      --urlpath="$MW_SCRIPT_PATH/sitemap/$MW_SITEMAP_SUBDIR" \
+      --urlpath="$SCRIPT_PATH/sitemap/$MW_SITEMAP_SUBDIR" \
       --compress yes \
       --server="$MW_SITE_SERVER" \
       --skip-redirects \


### PR DESCRIPTION
The variable `MW_SCRIPT_PATH` has been replaced with `SCRIPT_PATH` in `mwsitemapgen.sh` script to correct the URL path for the generated sitemaps.

Fixes unnoticed regression introduced by https://github.com/WikiTeq/Taqasta/commit/18d4c10a74139d0157585a2231374bcf67c1ad12#diff-1864538ef6bc1c7f8acbb3829c86188ff328611a7f05d8a5772400b302a41d74L23

MBSD-178