### PR TITLE
Switches Sentry extension to WikiTeq fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -827,7 +827,7 @@ RUN set -x; \
 	# Sentry (WikiTeq fork that uses sentry/sentry 3.x)
 	&& git clone --single-branch -b master https://github.com/WikiTeq/mediawiki-extensions-Sentry.git $MW_HOME/extensions/Sentry \
 	&& cd $MW_HOME/extensions/Sentry \
-	&& git checkout -q d0e599a23f374ee7260ebe421437e39cba89c2ba \
+	&& git checkout -q 9d9162d83f921b66f6c14ed354d20607ecafa030 \
 	# ShowMe
 	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/ShowMe $MW_HOME/extensions/ShowMe \
 	&& cd $MW_HOME/extensions/ShowMe \

--- a/Dockerfile
+++ b/Dockerfile
@@ -824,10 +824,10 @@ RUN set -x; \
 	&& rmdir SemanticQueryInterface \
 	&& ln -s SQI.php SemanticQueryInterface.php \
 	&& rm -fr .git \
-	# Sentry
-	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/Sentry $MW_HOME/extensions/Sentry \
+	# Sentry (WikiTeq fork that uses sentry/sentry 3.x)
+	&& git clone --single-branch -b master https://github.com/WikiTeq/mediawiki-extensions-Sentry.git $MW_HOME/extensions/Sentry \
 	&& cd $MW_HOME/extensions/Sentry \
-	&& git checkout -q 92c1ccc21c7bf45d723c604b52efdb2464057844 \
+	&& git checkout -q d0e599a23f374ee7260ebe421437e39cba89c2ba \
 	# ShowMe
 	&& git clone --single-branch -b $MW_VERSION https://gerrit.wikimedia.org/r/mediawiki/extensions/ShowMe $MW_HOME/extensions/ShowMe \
 	&& cd $MW_HOME/extensions/ShowMe \


### PR DESCRIPTION
The fork uses sentry/sentry 3.x which is necessary for modern Sentry-compatible protocols interactions (Sentry, GlitchTip, etc)