### PR TITLE
Allow to run setup scripts synchronously

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1025,7 +1025,8 @@ ENV MW_AUTOUPDATE=true \
 	MEDIAWIKI_MAINTENANCE_AUTO_ENABLED=false \
 	MW_DEBUG_MODE=false \
 	MW_SENTRY_DSN="" \
-	MW_USE_CACHE_DIRECTORY=1
+	MW_USE_CACHE_DIRECTORY=1 \
+	FAST_BOOT=1
 
 COPY _sources/configs/msmtprc /etc/
 COPY _sources/configs/mediawiki.conf /etc/apache2/sites-enabled/

--- a/_sources/scripts/run-apache.sh
+++ b/_sources/scripts/run-apache.sh
@@ -68,11 +68,19 @@ make_dir_writable "$MW_VOLUME" -not '(' -path "$MW_VOLUME/images" -prune ')'
 
 # Check and update permissions of wiki images in background.
 # It can take a long time and should not block Apache from starting.
-/update-images-permissions.sh &
+if isTrue "$FAST_BOOT"; then
+    /update-images-permissions.sh &
+else
+    /update-images-permissions.sh
+fi
 
 # Run maintenance scripts in background.
 touch "$WWW_ROOT/.maintenance"
-/run-maintenance-scripts.sh &
+if isTrue "$FAST_BOOT"; then
+    /run-maintenance-scripts.sh &
+else
+    /run-maintenance-scripts.sh
+fi
 
 ############### Run Apache ###############
 # Make sure we're not confused by old, incompletely-shutdown Apache


### PR DESCRIPTION
Adds new `FAST_BOOT` env. variable (enabled by default), if set to `0` will ensure all the setup and maintenance scripts are completed before starting Apache web server