### PR TITLE
Only log meaningful things in job queue log

### DIFF
--- a/_sources/scripts/mwjobrunner.sh
+++ b/_sources/scripts/mwjobrunner.sh
@@ -14,24 +14,20 @@ while true; do
         /rotatelogs-compress.sh "$logfileNow" "$logFilePrev" &
     fi
 
-    date >> "$logfileNow"
     # Job types that need to be run ASAP mo matter how many of them are in the queue
     # Those jobs should be very "cheap" to run
-    php "$RJ" --memory-limit="$MW_JOB_RUNNER_MEMORY_LIMIT" --type="enotifNotify" >> "$logfileNow" 2>&1
+    php "$RJ" --memory-limit="$MW_JOB_RUNNER_MEMORY_LIMIT" --type="enotifNotify" 2>&1 | grep -v "^Job queue is empty.$" >> "$logfileNow"
     sleep 1
-    php "$RJ" --memory-limit="$MW_JOB_RUNNER_MEMORY_LIMIT" --type="createPage" >> "$logfileNow" 2>&1
+    php "$RJ" --memory-limit="$MW_JOB_RUNNER_MEMORY_LIMIT" --type="createPage" 2&>1 | grep -v "^Job queue is empty.$" >> "$logfileNow"
     sleep 1
-    php "$RJ" --memory-limit="$MW_JOB_RUNNER_MEMORY_LIMIT" --type="htmlCacheUpdate" --maxjobs=500 >> "$logfileNow" 2>&1
+    php "$RJ" --memory-limit="$MW_JOB_RUNNER_MEMORY_LIMIT" --type="htmlCacheUpdate" --maxjobs=500 2>&1 | grep -v "^Job queue is empty.$" >> "$logfileNow"
     # Due to the way we do varnish cache reloading, we want to aim for htmlCacheUpdate jobs
     # to typically run before refreshLinks jobs, so do not sleep between them. (WLDR-314)
-    php "$RJ" --memory-limit="$MW_JOB_RUNNER_MEMORY_LIMIT" --type="refreshLinks" --maxjobs=25 >> "$logfileNow" 2>&1
+    php "$RJ" --memory-limit="$MW_JOB_RUNNER_MEMORY_LIMIT" --type="refreshLinks" --maxjobs=25 2>&1 | grep -v "^Job queue is empty.$" >> "$logfileNow"
     sleep 1
     # Everything else, limit the number of jobs on each batch
-    # The --wait parameter will pause the execution here until new jobs are added,
-    # to avoid running the loop without anything to do
-    php "$RJ" --memory-limit="$MW_JOB_RUNNER_MEMORY_LIMIT" --maxjobs=10 >> "$logfileNow" 2>&1
+    php "$RJ" --memory-limit="$MW_JOB_RUNNER_MEMORY_LIMIT" --maxjobs=10 2>&1 | grep -v "^Job queue is empty.$" >> "$logfileNow"
 
     # Wait some seconds to let the CPU do other things, like handling web requests, etc
-    echo mwjobrunner waits for "$MW_JOB_RUNNER_PAUSE" seconds... >> "$logfileNow"
     sleep "$MW_JOB_RUNNER_PAUSE"
 done

--- a/_sources/scripts/mwjobrunner.sh
+++ b/_sources/scripts/mwjobrunner.sh
@@ -18,7 +18,7 @@ while true; do
     # Those jobs should be very "cheap" to run
     php "$RJ" --memory-limit="$MW_JOB_RUNNER_MEMORY_LIMIT" --type="enotifNotify" 2>&1 | grep -v "^Job queue is empty.$" >> "$logfileNow"
     sleep 1
-    php "$RJ" --memory-limit="$MW_JOB_RUNNER_MEMORY_LIMIT" --type="createPage" 2&>1 | grep -v "^Job queue is empty.$" >> "$logfileNow"
+    php "$RJ" --memory-limit="$MW_JOB_RUNNER_MEMORY_LIMIT" --type="createPage" 2>&1 | grep -v "^Job queue is empty.$" >> "$logfileNow"
     sleep 1
     php "$RJ" --memory-limit="$MW_JOB_RUNNER_MEMORY_LIMIT" --type="htmlCacheUpdate" --maxjobs=500 2>&1 | grep -v "^Job queue is empty.$" >> "$logfileNow"
     # Due to the way we do varnish cache reloading, we want to aim for htmlCacheUpdate jobs

--- a/_sources/scripts/mwtranscoder.sh
+++ b/_sources/scripts/mwtranscoder.sh
@@ -14,12 +14,10 @@ while true; do
         /rotatelogs-compress.sh "$logfileNow" "$logFilePrev" &
     fi
 
-    date >> "$logfileNow"
-    php "$RJ" --type webVideoTranscodePrioritized --maxjobs=10 >> "$logfileNow" 2>&1
+    php "$RJ" --type webVideoTranscodePrioritized --maxjobs=10 | grep -v "^Job queue is empty.$" >> "$logfileNow" 2>&1
     sleep 1
-    php "$RJ" --type webVideoTranscode --maxjobs=1 >> "$logfileNow" 2>&1
+    php "$RJ" --type webVideoTranscode --maxjobs=1 | grep -v "^Job queue is empty.$" >> "$logfileNow" 2>&1
 
     # Wait some seconds to let the CPU do other things, like handling web requests, etc
-    echo mwtranscoder waits for "$MW_JOB_TRANSCODER_PAUSE" seconds... >> "$logfileNow"
     sleep "$MW_JOB_TRANSCODER_PAUSE"
 done


### PR DESCRIPTION
The previous version logged a lot of things that did not matter. Instead only log actual job actions. This saves space and makes it easier to tail the log when looking for things.

WIK-1171