### PR TITLE
Update variable in sitemap generation script (#95)

### DIFF
--- a/_sources/scripts/mwsitemapgen.sh
+++ b/_sources/scripts/mwsitemapgen.sh
@@ -44,7 +44,7 @@ while true; do
     # generate the sitemap
     php "$SCRIPT" \
       --fspath="$MW_HOME/sitemap/$MW_SITEMAP_SUBDIR" \
-      --urlpath="$MW_SCRIPT_PATH/sitemap/$MW_SITEMAP_SUBDIR" \
+      --urlpath="$SCRIPT_PATH/sitemap/$MW_SITEMAP_SUBDIR" \
       --compress yes \
       --server="$MW_SITE_SERVER" \
       --skip-redirects \


### PR DESCRIPTION
The variable `MW_SCRIPT_PATH` has been replaced with `SCRIPT_PATH` in `mwsitemapgen.sh` script to correct the URL path for the generated sitemaps.

MBSD-178

(cherry picked from commit 59cd21cdbd03c56b4bde163c14c47fb6ca755769)