### PR TITLE
DockerSettings: drop old security fixes

### DIFF
--- a/_sources/canasta/DockerSettings.php
+++ b/_sources/canasta/DockerSettings.php
@@ -595,12 +595,6 @@ if ( $wgSentryDsn ) {
 	wfLoadExtension( 'Sentry' );
 }
 
-# Fixes CVE-2021-44858, CVE-2021-45038, CVE-2021-44857, https://www.mediawiki.org/wiki/2021-12_security_release/FAQ
-$wgActions['mcrundo'] = false;
-$wgActions['mcrrestore'] = false;
-$wgWhitelistRead = [];
-$wgWhitelistReadRegexp = [];
-
 if ( isset( $_REQUEST['forceprofile'] ) ) {
 	$wgProfiler['class'] = 'ProfilerXhprof';
 	$wgProfiler['output'] = [ 'ProfilerOutputText' ];


### PR DESCRIPTION
No longer needed for MediaWiki 1.39

WIK-1301