### PR TITLE
Update MediaWiki core to 1.35.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainers="pastakhov@yandex.ru,alexey@wikiteq.com"
 LABEL org.opencontainers.image.source=https://github.com/WikiTeq/Taqasta
 
 ENV MW_VERSION=REL1_35 \
-	MW_CORE_VERSION=1.35.8 \
+	MW_CORE_VERSION=1.35.14 \
 	WWW_ROOT=/var/www/mediawiki \
 	MW_HOME=/var/www/mediawiki/w \
 	MW_LOG=/var/log/mediawiki \


### PR DESCRIPTION
Latest security update, expected to be the last release of MediaWiki 1.35, see wikitech-l announcement at https://w.wiki/8gQK.