### PR TITLE
Update Apache configuration to use X-Forwarded-For header for remote IP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1036,7 +1036,8 @@ ENV MW_AUTOUPDATE=true \
 	MEDIAWIKI_MAINTENANCE_AUTO_ENABLED=false \
 	MW_DEBUG_MODE=false \
 	MW_SENTRY_DSN="" \
-	MW_USE_CACHE_DIRECTORY=1
+	MW_USE_CACHE_DIRECTORY=1 \
+	APACHE_REMOTE_IP_HEADER=X-Forwarded-For
 
 COPY _sources/configs/msmtprc /etc/
 COPY _sources/configs/mediawiki.conf /etc/apache2/sites-enabled/

--- a/_sources/configs/mediawiki.conf
+++ b/_sources/configs/mediawiki.conf
@@ -26,7 +26,7 @@ RedirectMatch 404 /\.git
 Options -Indexes
 
 ######## Overwrite log format to include X-Forwarded-For if it is provided ########
-RemoteIPHeader X-Forwarded-For
+RemoteIPHeader ${APACHE_REMOTE_IP_HEADER}
 RemoteIPInternalProxy 10.0.0.0/8
 RemoteIPInternalProxy 172.16.0.0/12
 RemoteIPInternalProxy 192.168.0.0/16


### PR DESCRIPTION
https://wikiteq.atlassian.net/browse/WIK-1494 

Add the `APACHE_REMOTE_IP_HEADER`  if exist as env vars overwrites `X-Forwarded-For`