### PR TITLE
Profiling tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ RUN set x; \
 	php8.1-tidy \
 	php8.1-zip \
 	php8.1-tideways \
+	php8.1-excimer \
 # Lua sandbox
 	php-pear \
 	php8.1-dev \


### PR DESCRIPTION
- Pass some additional flags into xhprof when running with forceprofile to make the output more meaningful.
- Install Excimer into the Docker image.
- Make an excimer trace file (can be visualized as a flamegraph) when forceprofile is set.

There are some things that aren't quite done yet but should probably be done before merging, but I could use some more input/guidance in implementing them:
- We should add some form of retention for saved excimer traces (i.e. automatically delete traces older than X days / keep only the Y most recent traces). Otherwise someone could spam forceprofile=1 and fill up the log volume's disk.
- I would like to also implement passive excimer profiling on all web requests, with a sensible sampling frequency. The frequency should probably be dictated by an environment variable since every wiki is different and this is not a one-size-fits-all solution. Low traffic wikis would benefit from more frequent sampling but high traffic wikis need it turned down to avoid filling disk with traces.
- Is there a better spot to be shipping the excimer traces compared to the local log directory? Would be good to have central visibility on them if that's something we have for other things.