### PR TITLE
Update core to 1.39.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainers="pavel@wikiteq.com,alexey@wikiteq.com"
 LABEL org.opencontainers.image.source=https://github.com/WikiTeq/Taqasta
 
 ENV MW_VERSION=REL1_39 \
-	MW_CORE_VERSION=1.39.8 \
+	MW_CORE_VERSION=1.39.10 \
 	WWW_ROOT=/var/www/mediawiki \
 	MW_HOME=/var/www/mediawiki/w \
 	MW_LOG=/var/log/mediawiki \


### PR DESCRIPTION
We had multiple tasks where we need to update the taqasta core as there is new mediawiki security update 1.39.10. So I've updated the docker file and build the image locally and spawn new mediawiki. 

MBSD-307