### PR TITLE
MassMessage + MassMessageEmail: apply email hook inside MassMessage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -963,6 +963,13 @@ RUN set -x; \
     # WLDR-303
     && GIT_COMMITTER_EMAIL=docker@docker.invalid git cherry-pick -x 94ceca65c23a2894da1a26445077c786671aef0c
 
+# Apply patch to hook MassMessage to MassMessageEmail, DEMO-122
+# This should be removed after upgrading to MW 1.43 and MassMessage 0.5
+COPY _sources/patches/mass-message-email-hook.patch /tmp/MassMessage-email-hook.patch
+RUN set -x; \
+	cd $MW_HOME/extensions/MassMessage \
+	&& git apply /tmp/MassMessage-email-hook.patch
+
 # Fixes PHP parsoid errors when user replies on a flow message, see https://phabricator.wikimedia.org/T260648#6645078
 COPY _sources/patches/flow-conversion-utils.patch /tmp/flow-conversion-utils.patch
 RUN set -x; \

--- a/_sources/patches/mass-message-email-hook.patch
+++ b/_sources/patches/mass-message-email-hook.patch
@@ -1,0 +1,32 @@
+From 0825fe697bd9b6c9c778798ae233e9cf5c437474 Mon Sep 17 00:00:00 2001
+From: Brent Laabs <bslaabs@gmail.com>
+Date: Thu, 19 Dec 2024 02:16:08 -0800
+Subject: [PATCH] Include hook for MassMessageEmail inside MassMessage (1.39)
+
+Per the extension's install instructions, we need to patch in
+a new hook into MassMessage, so that emails are sent instead of
+just messaging on talk pages.  This should only be relevant for
+Mediawiki 1.39 LTS, as the hook is included in the >=1.43
+version of MassMessage.
+---
+ includes/Job/MassMessageJob.php | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/includes/Job/MassMessageJob.php b/includes/Job/MassMessageJob.php
+index 634c194..0a80ad3 100644
+--- a/includes/Job/MassMessageJob.php
++++ b/includes/Job/MassMessageJob.php
+@@ -317,7 +317,9 @@ class MassMessageJob extends Job {
+ 			&& !$targetPage->inNamespace( NS_TOPIC );
+ 
+ 		// If the page is using a different discussion system, handle it specially
+-		if ( $isLqtThreads || $isStructuredDiscussion ) {
++		if ( !\Hooks::run( 'MassMessageJobBeforeMessageSent', [ $this, $targetPage, $subject, $message, $pageSubject, $pageMessage, $comment ] ) ) {
++			return true;
++		} elseif ( $isLqtThreads || $isStructuredDiscussion ) {
+ 			$subject = $messageBuilder->buildPlaintextSubject( $subject, $pageSubject );
+ 			$message = $messageBuilder->buildMessage(
+ 				$messageBuilder->stripTildes( $message ),
+-- 
+2.45.1
+


### PR DESCRIPTION
DEMO-122

Following the install instructions for MassMessageEmail means patching the MassMessage file to call another hook.

This issue is fixed in MassMessage 0.5.0, which requires Mediawiki 1.43 -- which means that this fix should be removed when the version upgrade happens in the near future.