### PR TITLE
Replaces `mountpoint` check for import volume

### DIFF
--- a/_sources/scripts/run-maintenance-scripts.sh
+++ b/_sources/scripts/run-maintenance-scripts.sh
@@ -378,7 +378,7 @@ run_autoupdate () {
 
 run_import () {
     # Import PagePort dumps if any
-    if mountpoint -q -- "$MW_IMPORT_VOLUME"; then
+    if [ -d "$MW_IMPORT_VOLUME" ]; then
         echo "Found $MW_IMPORT_VOLUME, running PagePort import.."
         XML_TEST=($(find $MW_IMPORT_VOLUME -maxdepth 1 -name "*.xml"))
         if [ ${#XML_TEST[@]} -gt 0 ]; then


### PR DESCRIPTION
This change is needed to allow the import volume to be transitioned from a bind mount to a regular volume / on-image stored directory. This is necessary for the k8s deployment of the image where the import directory must not be a bind-mounted volume