### PR TITLE
Adds --wait param for the common jobs runner script

### DIFF
--- a/_sources/scripts/mwjobrunner.sh
+++ b/_sources/scripts/mwjobrunner.sh
@@ -29,7 +29,7 @@ while true; do
     # Everything else, limit the number of jobs on each batch
     # The --wait parameter will pause the execution here until new jobs are added,
     # to avoid running the loop without anything to do
-    php "$RJ" --memory-limit="$MW_JOB_RUNNER_MEMORY_LIMIT" --maxjobs=10 >> "$logfileNow" 2>&1
+    php "$RJ" --memory-limit="$MW_JOB_RUNNER_MEMORY_LIMIT" --wait --maxjobs=10 >> "$logfileNow" 2>&1
 
     # Wait some seconds to let the CPU do other things, like handling web requests, etc
     echo mwjobrunner waits for "$MW_JOB_RUNNER_PAUSE" seconds... >> "$logfileNow"


### PR DESCRIPTION
This PR adds the `--wait` parameter to the runJobs script at mwjobrunner.sh, the one that runs non-priority common jobs. This alters the behaviour of the mwjobrunner.sh from starting & exiting every N seconds to starting, waiting to process N jobs and then exiting after N seconds delay

This improves CPU footprint for empty queues and keeps the jobs processing logic close to the original 