### PR TITLE
Exclude TimedMediaHandler jobs from the default queue

### DIFF
--- a/_sources/canasta/DockerSettings.php
+++ b/_sources/canasta/DockerSettings.php
@@ -705,6 +705,10 @@ if ( !empty( getenv( 'AWS_IMAGES_BUCKET' ) ) ) {
 	$wgAWSRepoDeletedHashLevels = 3;
 }
 
+# Make sure TimedMediaHandler jobs are excluded from the default queue, see QLOUD-147
+$wgJobTypesExcludedFromDefaultQueue[] = 'webVideoTranscode';
+$wgJobTypesExcludedFromDefaultQueue[] = 'webVideoTranscodePrioritized';
+
 # Include all php files in config/settings directory
 foreach ( glob( getenv( 'MW_CONFIG_DIR' ) . '/settings/*.php' ) as $filename ) {
 	if ( is_readable( $filename ) ) {


### PR DESCRIPTION
Make sure video transcoding jobs are not part of the default queue and that job runners must request them explicitly