### PR TITLE
Remove `LiquidThreads` extension

### DIFF
--- a/_sources/canasta/DockerSettings.php
+++ b/_sources/canasta/DockerSettings.php
@@ -117,7 +117,6 @@ const DOCKER_EXTENSIONS = [
 	'LinkSuggest',
 	'LinkTarget',
 	'Linter', # bundled
-	'LiquidThreads',
 	'LockAuthor',
 	'Lockdown',
 	'LoginNotify', # bundled

--- a/values.yml
+++ b/values.yml
@@ -307,8 +307,6 @@ extensions:
       repository: https://github.com/mudkipme/mediawiki-lazyload.git
       branch: master
       commit: 30a01cc149822353c9404ec178ec01848bae65c5
-  - LiquidThreads:
-      commit: f0d9a0de69623655ca57c40bcd10cb933d9ec99f
   - MassPasswordReset:
       repository: https://github.com/nischayn22/MassPasswordReset.git
       branch: master


### PR DESCRIPTION
The extension is currently unmaintained and we want to avoid needing to support it.

WIK-1921