### PR TITLE
PageForms: add patch to fix possible values

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -973,6 +973,11 @@ RUN set -x; \
     # WLDR-303
     && GIT_COMMITTER_EMAIL=docker@docker.invalid git cherry-pick -x 94ceca65c23a2894da1a26445077c786671aef0c
 
+COPY _sources/patches/PageForms-possible-values.patch /tmp/PageForms-possible-values.patch
+RUN set -x; \
+	cd $MW_HOME/extensions/PageForms \
+	&& git apply /tmp/PageForms-possible-values.patch
+
 # Fixes PHP parsoid errors when user replies on a flow message, see https://phabricator.wikimedia.org/T260648#6645078
 COPY _sources/patches/flow-conversion-utils.patch /tmp/flow-conversion-utils.patch
 RUN set -x; \

--- a/_sources/patches/PageForms-possible-values.patch
+++ b/_sources/patches/PageForms-possible-values.patch
@@ -1,0 +1,32 @@
+From 79123d762111b1297720f2c61af58f9057a2d288 Mon Sep 17 00:00:00 2001
+From: Daniel Scherzer <daniel@wikiteq.com>
+Date: Sat, 13 Sep 2025 18:55:14 -0700
+Subject: [PATCH] PageForms: fix bug with possible values
+
+In PFFormField::setPossibleValues() use the template field's possible values
+as a fallback only if there are no current values set.
+
+Copied from waldronlab/BugSigDB#192
+WLDR-338
+---
+ includes/PF_FormField.php | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/includes/PF_FormField.php b/includes/PF_FormField.php
+index 2ea770c6..99cc5cc0 100644
+--- a/includes/PF_FormField.php
++++ b/includes/PF_FormField.php
+@@ -548,7 +548,9 @@ class PFFormField {
+ 			return;
+ 		}
+ 
+-		$this->mPossibleValues = $this->template_field->getPossibleValues();
++		if ( $this->mPossibleValues === null ) {
++			$this->mPossibleValues = $this->template_field->getPossibleValues();
++		}
+ 	}
+ 
+ 	function cleanupTranslateTags( &$value ) {
+-- 
+2.49.0.windows.1
+


### PR DESCRIPTION
In PFFormField::setPossibleValues() use the template field's possible values as a fallback only if there are no current values set.

WLDR-338