### PR TITLE
values.yml: fix TemplateStyles entries

### DIFF
--- a/values.yml
+++ b/values.yml
@@ -15,11 +15,6 @@ extensions:
       bundled: true
       additional steps:
         - composer update
-  - TemplateStyles:
-      Wikidata ID: Q25916623
-      bundled: true
-      additional steps:
-        - composer update
   - AdminLinks:
       Wikidata ID: Q21676187
       branch: master
@@ -314,6 +309,8 @@ extensions:
   - TemplateStyles:
       Wikidata ID: Q25916623
       commit: 31a4bd259a921e19b4857befa700e7fc0998b6d2
+      additional steps:
+        - composer update
   - TemplateWizard:
       Wikidata ID: Q50368282
       commit: 4c3057f1bf55f686f044dce40b9e70e14ea8d8ec


### PR DESCRIPTION
There were two entries, on which claimed to be bundled and properly documented the `composer update` step, and the second that checked out a commit and didn't have the composer step. Remove the incorrect entry for the extension being bundled and update the remaining entry with the composer step.

WIK-2077