### PR TITLE
Trust Cloudflare CIDRs in mod_remoteip for X-Forwarded-For

### DIFF
--- a/_sources/configs/mediawiki.conf
+++ b/_sources/configs/mediawiki.conf
@@ -33,6 +33,29 @@ RemoteIPHeader ${APACHE_REMOTE_IP_HEADER}
 RemoteIPInternalProxy 10.0.0.0/8
 RemoteIPInternalProxy 172.16.0.0/12
 RemoteIPInternalProxy 192.168.0.0/16
+# Cloudflare edge IP ranges (https://www.cloudflare.com/ips-v4, https://www.cloudflare.com/ips-v6)
+RemoteIPTrustedProxy 173.245.48.0/20
+RemoteIPTrustedProxy 103.21.244.0/22
+RemoteIPTrustedProxy 103.22.200.0/22
+RemoteIPTrustedProxy 103.31.4.0/22
+RemoteIPTrustedProxy 141.101.64.0/18
+RemoteIPTrustedProxy 108.162.192.0/18
+RemoteIPTrustedProxy 190.93.240.0/20
+RemoteIPTrustedProxy 188.114.96.0/20
+RemoteIPTrustedProxy 197.234.240.0/22
+RemoteIPTrustedProxy 198.41.128.0/17
+RemoteIPTrustedProxy 162.158.0.0/15
+RemoteIPTrustedProxy 104.16.0.0/13
+RemoteIPTrustedProxy 104.24.0.0/14
+RemoteIPTrustedProxy 172.64.0.0/13
+RemoteIPTrustedProxy 131.0.72.0/22
+RemoteIPTrustedProxy 2400:cb00::/32
+RemoteIPTrustedProxy 2606:4700::/32
+RemoteIPTrustedProxy 2803:f800::/32
+RemoteIPTrustedProxy 2405:b500::/32
+RemoteIPTrustedProxy 2405:8100::/32
+RemoteIPTrustedProxy 2a06:98c0::/29
+RemoteIPTrustedProxy 2c0f:f248::/32
 
 LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" docker
 


### PR DESCRIPTION
Requests that reach the wiki pods often go through Cloudflare → Traefik → Apache. Traefik already sets a meaningful X-Forwarded-For when it trusts Cloudflare. Apache’s mod_remoteip must treat Cloudflare edge IPs as trusted proxies in that header chain