### PR TITLE
Bump Composer to 2.10.1 for GitHub token compatibility

### DIFF
--- a/templates/base.Dockerfile
+++ b/templates/base.Dockerfile
@@ -113,4 +113,4 @@ RUN set -x; \
 # Composer
 RUN set -x; \
 	curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
-	composer self-update 2.8.12
+	composer self-update 2.10.1


### PR DESCRIPTION
Composer 2.8.12 rejects modern GITHUB_TOKEN (ghs_...) values during docker build, breaking CI composer update steps.