### PR TITLE
Fix CI wiki init wait: use pre-built image and fail fast on bootstrap errors

### DIFF
--- a/.github/scripts/wait-for-wiki-init.sh
+++ b/.github/scripts/wait-for-wiki-init.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Wait for run-maintenance-scripts.sh marker; stream web logs to CI output.
+set -euo pipefail
+
+MARKER='>>>>> run-maintenance-script.sh <<<<<'
+LOG_FILE=/tmp/taqasta-web-init.log
+
+: >"$LOG_FILE"
+docker compose logs web >>"$LOG_FILE" 2>&1 || true
+
+docker compose logs -f web 2>&1 | tee -a "$LOG_FILE" &
+logs_pid=$!
+trap 'kill "$logs_pid" 2>/dev/null; wait "$logs_pid" 2>/dev/null || true' EXIT
+
+while ! grep -Fq "$MARKER" "$LOG_FILE"; do
+	sleep 1
+done

--- a/.github/scripts/wait-for-wiki-init.sh
+++ b/.github/scripts/wait-for-wiki-init.sh
@@ -29,7 +29,23 @@ fail_fast() {
 	return 1
 }
 
+MAX_WAIT_SECONDS="${MAX_WAIT_SECONDS:-600}"
+start_ts="$(date +%s)"
+
 while ! grep -Fq "$MARKER" "$LOG_FILE"; do
+	now_ts="$(date +%s)"
+	if [ $((now_ts - start_ts)) -ge "$MAX_WAIT_SECONDS" ]; then
+		echo "Timeout: marker not found within ${MAX_WAIT_SECONDS}s" >&2
+		tail -40 "$LOG_FILE" >&2 || true
+		exit 1
+	fi
+
+	if ! kill -0 "$logs_pid" 2>/dev/null; then
+		echo "Log follower exited before init marker was detected" >&2
+		tail -40 "$LOG_FILE" >&2 || true
+		exit 1
+	fi
+
 	if fail_fast; then
 		tail -40 "$LOG_FILE" >&2
 		exit 1

--- a/.github/scripts/wait-for-wiki-init.sh
+++ b/.github/scripts/wait-for-wiki-init.sh
@@ -12,6 +12,27 @@ docker compose logs -f web 2>&1 | tee -a "$LOG_FILE" &
 logs_pid=$!
 trap 'kill "$logs_pid" 2>/dev/null; wait "$logs_pid" 2>/dev/null || true' EXIT
 
+fail_fast() {
+	local fatal_count
+
+	fatal_count=$(grep -cE 'Fatal error:|PHP Fatal error:' "$LOG_FILE" 2>/dev/null || true)
+	if [ "$fatal_count" -eq 0 ]; then
+		return 1
+	fi
+
+	if grep -Fq 'Check wiki settings for errors' "$LOG_FILE" \
+		|| grep -Fq 'An error occurred while checking the wiki settings' "$LOG_FILE"; then
+		echo "Fail-fast: web init failed during settings check (fatal=$fatal_count)" >&2
+		return 0
+	fi
+
+	return 1
+}
+
 while ! grep -Fq "$MARKER" "$LOG_FILE"; do
+	if fail_fast; then
+		tail -40 "$LOG_FILE" >&2
+		exit 1
+	fi
 	sleep 1
 done

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Wait for init
         shell: bash
-        run: while ! docker compose logs web --tail 10 | grep -q '>>>>> run-maintenance-script.sh <<<<<'; do sleep 1; done
+        run: bash .github/scripts/wait-for-wiki-init.sh
 
       - name: Wait for container to be healthy
         shell: bash
@@ -270,7 +270,7 @@ jobs:
 
       - name: Wait for init
         shell: bash
-        run: while ! docker compose logs web --tail 10 | grep -q '>>>>> run-maintenance-script.sh <<<<<'; do sleep 1; done
+        run: bash .github/scripts/wait-for-wiki-init.sh
 
       - name: Wait for container to be healthy
         shell: bash

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -106,7 +106,15 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: docker compose exec -e COMPOSER_TOKEN=$GITHUB_TOKEN web composer update          
+        run: |
+          docker compose exec -T \
+            -e COMPOSER_ALLOW_SUPERUSER=1 \
+            -e COMPOSER_TOKEN="$GITHUB_TOKEN" \
+            web sh -c '
+              composer config -g github-oauth.github.com "$COMPOSER_TOKEN" &&
+              composer update &&
+              composer config -g --unset github-oauth.github.com
+            '
 
       - name: PHPUNIT - unit tests
         shell: bash

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -88,11 +88,11 @@ jobs:
 
       - name: Setup Docker Compose
         env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCKER_BUILDKIT: 1
+          TAQASTA_IMAGE: ${{ needs.tags.outputs.REGISTRY_TAGS }}
         shell: bash
         run: |
-          DOCKER_BUILDKIT=1 docker compose up -d
+          export TAQASTA_IMAGE="${TAQASTA_IMAGE%%,*}"
+          docker compose up -d --no-build
 
       - name: Wait for init
         shell: bash
@@ -262,11 +262,11 @@ jobs:
 
       - name: Setup Docker Compose
         env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCKER_BUILDKIT: 1
+          TAQASTA_IMAGE: ${{ needs.tags.outputs.REGISTRY_TAGS }}
         shell: bash
         run: |
-          DOCKER_BUILDKIT=1 docker compose up -d
+          export TAQASTA_IMAGE="${TAQASTA_IMAGE%%,*}"
+          docker compose up -d --no-build
 
       - name: Wait for init
         shell: bash

--- a/_sources/configs/composer.wikiteq.json.tmpl
+++ b/_sources/configs/composer.wikiteq.json.tmpl
@@ -30,7 +30,8 @@
 		{{- range $index, $ext := (ds "values").repositories }}
 		{
 			"type": "{{ $ext.type }}",
-			"url": "{{ $ext.url }}"
+			"url": "{{ $ext.url }}"{{ if has $ext "canonical" }},
+			"canonical": {{ index $ext "canonical" }}{{ end }}
 		}{{ if lt $index (sub (len (ds "values").repositories) 1) }},{{ end }}
 		{{- end }}
 	]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
         command: --default-authentication-plugin=caching_sha2_password --log-bin --binlog-expire-logs-seconds=172800
         cap_add:
             - SYS_NICE  # CAP_SYS_NICE, fix error mbind: Operation not permitted
-        restart: unless-stopped
+        restart: "no"
         environment:
             - MYSQL_ROOT_HOST=%
             - MYSQL_ROOT_PASSWORD=${MW_DB_INSTALLDB_PASS:-mediawiki}
@@ -15,10 +15,11 @@ services:
             - mysql:/var/lib/mysql
 
     web:
+        image: ${TAQASTA_IMAGE:-taqasta-web}
         build:
             context: .
             dockerfile: Dockerfile
-        restart: unless-stopped
+        restart: "no"
         ports:
             - "${PORT:-127.0.0.1:8000}:80"
         depends_on:

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,18 +9,18 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "1.49.1",
+        "@playwright/test": "1.57.0",
         "@types/node": "22.10.7"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
-      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.49.1"
+        "playwright": "1.57.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -55,13 +55,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
-      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.49.1"
+        "playwright-core": "1.57.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -74,9 +74,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
-      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "1.49.1",
+    "@playwright/test": "1.57.0",
     "@types/node": "22.10.7"
   }
 }

--- a/templates/composer.Dockerfile
+++ b/templates/composer.Dockerfile
@@ -46,11 +46,10 @@ RUN set -x; \
 COPY _sources/configs/composer.wikiteq.json $MW_HOME/composer.local.json
 
 # merge-plugin and composer/installers must run as root during docker build
-ENV COMPOSER_ALLOW_SUPERUSER=1
-
 # Run with secret mounted to /run/secrets/COMPOSER_TOKEN
 # This is needed to bypass rate limits
 RUN --mount=type=secret,id=COMPOSER_TOKEN cd $MW_HOME && \
+	export COMPOSER_ALLOW_SUPERUSER=1 && \
 	cp composer.json composer.json.bak && \
 	cat composer.json.bak | jq '. + {"minimum-stability": "dev"}' > composer.json && \
 	rm composer.json.bak && \

--- a/templates/composer.Dockerfile
+++ b/templates/composer.Dockerfile
@@ -45,6 +45,9 @@ RUN set -x; \
 # Composer dependencies
 COPY _sources/configs/composer.wikiteq.json $MW_HOME/composer.local.json
 
+# merge-plugin and composer/installers must run as root during docker build
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
 # Run with secret mounted to /run/secrets/COMPOSER_TOKEN
 # This is needed to bypass rate limits
 RUN --mount=type=secret,id=COMPOSER_TOKEN cd $MW_HOME && \

--- a/values.schema.json
+++ b/values.schema.json
@@ -141,6 +141,10 @@
             "type": "string",
             "format": "uri",
             "description": "Repository URL"
+          },
+          "canonical": {
+            "type": "boolean",
+            "description": "When true, this repository overrides Packagist for the same package name"
           }
         },
         "additionalProperties": false,

--- a/values.yml
+++ b/values.yml
@@ -550,7 +550,8 @@ packages:
   - name: mediawiki/chameleon-skin
     version: 5.0.0
   - name: mediawiki/bootstrap-components
-    version: dev-master#476693d7a0f0de11bb67b775486950bff5cd1415 # >5.2.1
+    # 476693d on rel-522; avoid dev-master (Packagist alias requires bootstrap ^6, breaks chameleon 5.0.0)
+    version: dev-rel-522#476693d7a0f0de11bb67b775486950bff5cd1415
   - name: mediawiki/mermaid
     version: 3.1.0
   - name: mediawiki/remote-wiki
@@ -581,6 +582,9 @@ repositories:
     url: https://github.com/WikiTeq/mediawiki-api-base.git
   - type: vcs
     url: https://github.com/WikiTeq/mediawiki-extension-RemoteWiki
+  - type: vcs
+    url: https://github.com/oetterer/BootstrapComponents.git
+    canonical: true
 # patches to apply; name is the file name in _sources/patches and path is
 # the git directory to apply it to in the built image, relative to $MW_HOME
 patches:


### PR DESCRIPTION
Fix CI wiki init wait: use pre-built image and fail fast on bootstrap errors
CI test and deploy-e2e no longer rebuild the web image on docker compose up;
they reuse the image loaded in Build and load (TAQASTA_IMAGE from REGISTRY_TAGS).
Add wait-for-wiki-init.sh to stream full web logs and wait for the maintenance
marker in the accumulated log instead of grep on --tail 10.
Use restart: no in CI compose so fatal init errors do not loop until job timeout.
Fail fast when settings check logs a PHP fatal before the marker appears.